### PR TITLE
fixed email uncontrolled to controlled error

### DIFF
--- a/src/views/profile/ProfileView.tsx
+++ b/src/views/profile/ProfileView.tsx
@@ -10,7 +10,7 @@ type MyProps = { }
 type MyState = { }
 
 const ProfileView = (props:any) => {
-    const [ email, setEmail ] = useState();
+    const [ email, setEmail ] = useState('');
 
     return(
         <main className={profileStyle.ProfileWrapper}>


### PR DESCRIPTION
Uncontrolled to controlled happened because email is used in input field instead of a static one for example label.

The state was not initialized thus when stuff starts rendering email is undefined and later becomes defined.